### PR TITLE
Fix typo in `[:print:]` equivalence note

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The POSIX standard supports the following classes or categories of charactersh (
 | `[:digit:]` | `[0-9]` | digits |
 | `[:graph:]` | `[^[:cntrl:]]` | graphic characters (all characters which have graphic representation) |
 | `[:lower:]` | `[a-z]` | lowercase letters |
-| `[:print:]` | `[[:graph] ]` | graphic characters and space |
+| `[:print:]` | `[[:graph:] ]` | graphic characters and space |
 | `[:punct:]` | ``[-!"#$%&'()*+,./:;<=>?@[]^_`{\|}~]`` | all punctuation characters (all graphic characters except letters and digits) |
 | `[:space:]` | `[ \t\n\r\f\v]` | all blank (whitespace) characters, including spaces, tabs, new lines, carriage returns, form feeds, and vertical tabs |
 | `[:upper:]` | `[A-Z]` | uppercase letters |


### PR DESCRIPTION
Just noticed this tiny typo, why not fix it?..