### PR TITLE
Fix typo in `[:graph:]` equivalence note

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The POSIX standard supports the following classes or categories of charactersh (
 | `[:blank:]` | `[ \t]` | space and TAB characters only |
 | `[:cntrl:]` | `[\x00-\x1F\x7F]` | Control characters |
 | `[:digit:]` | `[0-9]` | digits |
-| `[:graph:]` | `[^[:cntrl:]]` | graphic characters (all characters which have graphic representation) |
+| `[:graph:]` | `[^ [:cntrl:]]` | graphic characters (all characters which have graphic representation) |
 | `[:lower:]` | `[a-z]` | lowercase letters |
 | `[:print:]` | `[[:graph:] ]` | graphic characters and space |
 | `[:punct:]` | ``[-!"#$%&'()*+,./:;<=>?@[]^_`{\|}~]`` | all punctuation characters (all graphic characters except letters and digits) |


### PR DESCRIPTION
Referenced wikibooks actually contains space; apparently it was lost
during porting to this README.md.

    https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions#Character_classes

Fixes #3.