### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,13 @@ node_js:
   - '4'
   - '0.12'
   - '0.10'
+matrix:
+    include:
+         - node_js: "7"
+           arch: ppc64le
+         - node_js: "6"
+           arch: ppc64le
+         - node_js: "5"
+           arch: ppc64le
+         - node_js: "node"
+           arch: ppc64le


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. Travis Job details
https://www.travis-ci.com/github/kishorkunal-raj/posix-character-classes/builds/210192471

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj